### PR TITLE
Possible bug in ephemeron_get_*_copy

### DIFF
--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -355,24 +355,27 @@ CAMLexport int caml_ephemeron_get_key_copy(value ar, mlsize_t offset,
                                            value *key)
 {
   CAMLparam1(ar);
-  value elt,v; /* Caution: they are NOT a local root. */
+  value elt = Val_unit, v; /* Caution: they are NOT a local root. */
   Assert_valid_offset(ar,offset);
 
   offset += CAML_EPHE_FIRST_KEY;
 
-  if (is_ephe_key_none(ar, offset)) CAMLreturn(0);
-  v = Field (ar, offset);
-  if (Is_block (v) && Is_in_heap_or_young(v)) {
-    elt = caml_alloc (Wosize_val (v), Tag_val (v));
-          /* The GC may erase or move v during this call to caml_alloc. */
-    if (is_ephe_key_none(ar, offset)) CAMLreturn(0);
+  while(1) {
+    if(is_ephe_key_none(ar, offset)) CAMLreturn(0);
     v = Field (ar, offset);
-    copy_value(v,elt);
-    *key = elt;
-    CAMLreturn(1);
-  }else{
-    *key = v;
-    CAMLreturn(1);
+    if(!(Is_block (v) && Is_in_heap_or_young(v))) {
+      *key = v;
+      CAMLreturn(1);
+    }
+    if (elt != Val_unit &&
+        Wosize_val(v) == Wosize_val(elt) && Tag_val(v) == Tag_val(elt)) {
+      copy_value(v,elt);
+      *key = elt;
+      CAMLreturn(1);
+    }
+    elt = caml_alloc (Wosize_val (v), Tag_val (v));
+    /* The GC may erase, move or even change v during this call to
+       caml_alloc. */
   }
 }
 
@@ -391,24 +394,26 @@ CAMLprim value caml_weak_get_copy (value ar, value n){
 CAMLexport int caml_ephemeron_get_data_copy (value ar, value *data)
 {
   CAMLparam1 (ar);
-  value elt,v; /* Caution: they are NOT a local root. */
+  value elt = Val_unit,v; /* Caution: they are NOT a local root. */
   Assert_valid_ephemeron(ar);
 
-  if (caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
-  v = Field (ar, CAML_EPHE_DATA_OFFSET);
-  if (v == caml_ephe_none) CAMLreturn(0);
-  if (Is_block (v) && Is_in_heap_or_young(v)) {
-    elt = caml_alloc (Wosize_val (v), Tag_val (v));
-          /* The GC may erase or move v during this call to caml_alloc. */
+  while(1) {
     if (caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
     v = Field (ar, CAML_EPHE_DATA_OFFSET);
     if (v == caml_ephe_none) CAMLreturn(0);
-    copy_value(v,elt);
-    *data=elt;
-    CAMLreturn(1);
-  }else{
-    *data = v;
-    CAMLreturn(1);
+    if (!(Is_block (v) && Is_in_heap_or_young(v))) {
+      *data = v;
+      CAMLreturn(1);
+    }
+    if (elt != Val_unit &&
+        Wosize_val(v) == Wosize_val(elt) && Tag_val(v) == Tag_val(elt)) {
+      copy_value(v,elt);
+      *data = elt;
+      CAMLreturn(1);
+    }
+    elt = caml_alloc (Wosize_val (v), Tag_val (v));
+    /* The GC may erase, move or even change v during this call to
+       caml_alloc. */
   }
 }
 


### PR DESCRIPTION
In caml_ephemeron_get_*_copy, the allocation may trigger a finalyzer that change the tag and size of the block. Therefore, in addition to checking that the pointer is still alive, we have to check that it still has the same tag and size.

I think this bug should be really hard to trigger, so it maybe not worth putting in 4.03. What do you think. 
